### PR TITLE
Updated required Java 7 dependency to avoid error.

### DIFF
--- a/roles/esnode/tasks/main.yml
+++ b/roles/esnode/tasks/main.yml
@@ -6,7 +6,7 @@
   tags: deps
 
 - name: Install Java7
-  apt: pkg=java7-runtime-headless update_cache=yes state=latest
+  apt: pkg=openjdk-7-jre-headless update_cache=yes state=latest
   tags: deps
 
 - name: Add Elasticsearch repository


### PR DESCRIPTION
 To avoid error: `{"failed": true} stderr: E: Package 'java7-runtime-headless' has no installation candidate`